### PR TITLE
Support arbitrary clouds

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ func main() {
 				"zpa_client_id": "",
 				"zpa_client_secret": "",
 				"zpa_customer_id": "",
-				"zpa_cloud": ""
+				"zpa_cloud": "https://config.private.zscaler.com"
 			}
 	*/
 	zpa_client_id := os.Getenv("ZPA_CLIENT_ID")

--- a/zpa/config.go
+++ b/zpa/config.go
@@ -104,6 +104,8 @@ func NewConfig(clientID, clientSecret, customerID, cloud, userAgent string) (*Co
 	rawUrl := defaultBaseURL
 	if cloud == "" {
 		cloud = os.Getenv(ZPA_CLOUD)
+	} else if cloud != "" {
+		rawUrl = cloud
 	}
 	if strings.EqualFold(cloud, "BETA") {
 		rawUrl = betaBaseURL


### PR DESCRIPTION
## Description

I work on the ZPA Ops team, and we have a few more clouds on the way, 
and a lot of development clouds, and I'd like to be able to tell internal users to use
terraform-provider-zpa, but they have to be able to point it at those
internal clouds.

This change will allow users to specify a precise URL instead of "",
"gov" or "beta", and have that go straight through.

Provide a general summary of your changes in the title above. You should
remove this overview, any sections and any section descriptions you
don't need below before submitting. There isn't a strict requirement to
use this template if you can structure your description and still cover
these points.

## Has your change been tested?

I've added some test cases and SDK side tests- it can auth and create an app connector group on a previously unsupported cloud. I haven't plumbed everything through to the terraform provider and tested there though.