### PR TITLE
log request duration and request ID

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.19
 
 require (
 	github.com/google/go-querystring v1.1.0
+	github.com/google/uuid v1.3.0
 	github.com/hashicorp/go-retryablehttp v0.7.2
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.26.1
 	github.com/stretchr/testify v1.8.2

--- a/go.sum
+++ b/go.sum
@@ -7,6 +7,8 @@ github.com/google/go-cmp v0.5.2/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/
 github.com/google/go-cmp v0.5.9 h1:O2Tfq5qg4qc4AmwVlvv0oLiVAGB7enBSJ2x2DqQFi38=
 github.com/google/go-querystring v1.1.0 h1:AnCroh3fv4ZBgVIf1Iwtovgjaw/GiKJo8M8yD/fhyJ8=
 github.com/google/go-querystring v1.1.0/go.mod h1:Kcdr2DB4koayq7X8pmAG4sNG59So17icRSOU623lUBU=
+github.com/google/uuid v1.3.0 h1:t6JiXgmwXMjEs8VusXIJk2BXHsn+wx8BZdTaoZ5fu7I=
+github.com/google/uuid v1.3.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/hashicorp/go-cleanhttp v0.5.2 h1:035FKYIWjmULyFRBKPs8TBQoi0x6d9G4xc9neXJWAZQ=
 github.com/hashicorp/go-cleanhttp v0.5.2/go.mod h1:kO/YDlP8L1346E6Sodw+PrpBSV4/SoxCXGY6BqNFT48=
 github.com/hashicorp/go-hclog v0.9.2/go.mod h1:5CU+agLiy3J7N7QjHK5d05KxGsuXiQLrjA0H7acj2lQ=

--- a/logger/logger.go
+++ b/logger/logger.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"strconv"
 	"strings"
+	"time"
 )
 
 type Logger interface {
@@ -45,12 +46,12 @@ func GetDefaultLogger(loggerPrefix string) Logger {
 
 const (
 	logReqMsg = `[DEBUG] Request "%s %s" details:
----[ ZSCALER SDK REQUEST ]-------------------------------
+---[ ZSCALER SDK REQUEST | ID:%s ]-------------------------------
 %s
 ---------------------------------------------------------`
 
 	logRespMsg = `[DEBUG] Response "%s %s" details:
----[ ZSCALER SDK RESPONSE ]--------------------------------
+---[ ZSCALER SDK RESPONSE | ID:%s | Duration:%s ]--------------------------------
 %s
 -------------------------------------------------------`
 )
@@ -61,20 +62,20 @@ func WriteLog(logger Logger, format string, args ...interface{}) {
 	}
 }
 
-func LogRequest(logger Logger, req *http.Request) {
+func LogRequest(logger Logger, req *http.Request, reqID string) {
 	if logger != nil && req != nil {
 		out, err := httputil.DumpRequestOut(req, true)
 		if err == nil {
-			WriteLog(logger, logReqMsg, req.Method, req.URL, string(out))
+			WriteLog(logger, logReqMsg, req.Method, req.URL, reqID, string(out))
 		}
 	}
 }
 
-func LogResponse(logger Logger, resp *http.Response) {
+func LogResponse(logger Logger, resp *http.Response, start time.Time, reqID string) {
 	if logger != nil && resp != nil {
 		out, err := httputil.DumpResponse(resp, true)
 		if err == nil {
-			WriteLog(logger, logRespMsg, resp.Request.Method, resp.Request.URL, string(out))
+			WriteLog(logger, logRespMsg, resp.Request.Method, resp.Request.URL, reqID, time.Since(start).String(), string(out))
 		}
 	}
 }

--- a/zcc/client.go
+++ b/zcc/client.go
@@ -9,8 +9,10 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+	"time"
 
 	"github.com/google/go-querystring/query"
+	"github.com/google/uuid"
 
 	"github.com/zscaler/zscaler-sdk-go/logger"
 )
@@ -87,8 +89,10 @@ func (client *Client) newRequestDoCustom(method, urlStr string, options, body, v
 	if err != nil {
 		return nil, err
 	}
-	logger.LogRequest(client.Config.Logger, req)
-	return client.do(req, v)
+	start := time.Now()
+	reqID := uuid.NewString()
+	logger.LogRequest(client.Config.Logger, req, reqID)
+	return client.do(req, v, start, reqID)
 }
 
 // Generating the Http request.
@@ -141,7 +145,7 @@ func (client *Client) newRequest(method, urlPath string, options, body interface
 	return req, nil
 }
 
-func (client *Client) do(req *http.Request, v interface{}) (*http.Response, error) {
+func (client *Client) do(req *http.Request, v interface{}, start time.Time, reqID string) (*http.Response, error) {
 	resp, err := client.Config.GetHTTPClient().Do(req)
 	if err != nil {
 		return nil, err
@@ -156,7 +160,7 @@ func (client *Client) do(req *http.Request, v interface{}) (*http.Response, erro
 			return resp, err
 		}
 	}
-	logger.LogResponse(client.Config.Logger, resp)
+	logger.LogResponse(client.Config.Logger, resp, start, reqID)
 	unescapeHTML(v)
 	return resp, nil
 }

--- a/zdx/client.go
+++ b/zdx/client.go
@@ -16,6 +16,7 @@ import (
 	"time"
 
 	"github.com/google/go-querystring/query"
+	"github.com/google/uuid"
 	"github.com/zscaler/zscaler-sdk-go/logger"
 )
 
@@ -97,8 +98,10 @@ func (client *Client) newRequestDoCustom(method, urlStr string, options, body, v
 	if err != nil {
 		return nil, err
 	}
-	logger.LogRequest(client.Config.Logger, req)
-	return client.do(req, v)
+	reqID := uuid.NewString()
+	start := time.Now()
+	logger.LogRequest(client.Config.Logger, req, reqID)
+	return client.do(req, v, start, reqID)
 }
 
 func generateHash(apiSecret string, currTimestamp int64) string {
@@ -158,7 +161,7 @@ func (client *Client) newRequest(method, urlPath string, options, body interface
 	return req, nil
 }
 
-func (client *Client) do(req *http.Request, v interface{}) (*http.Response, error) {
+func (client *Client) do(req *http.Request, v interface{}, start time.Time, reqID string) (*http.Response, error) {
 	resp, err := client.Config.GetHTTPClient().Do(req)
 	if err != nil {
 		return nil, err
@@ -173,7 +176,7 @@ func (client *Client) do(req *http.Request, v interface{}) (*http.Response, erro
 			return resp, err
 		}
 	}
-	logger.LogResponse(client.Config.Logger, resp)
+	logger.LogResponse(client.Config.Logger, resp, start, reqID)
 	unescapeHTML(v)
 	return resp, nil
 }

--- a/zia/client.go
+++ b/zia/client.go
@@ -8,7 +8,9 @@ import (
 	"io"
 	"net/http"
 	"reflect"
+	"time"
 
+	"github.com/google/uuid"
 	"github.com/zscaler/zscaler-sdk-go/logger"
 )
 
@@ -34,12 +36,14 @@ func (c *Client) Request(endpoint, method string, data []byte, contentType strin
 	if c.UserAgent != "" {
 		req.Header.Add("User-Agent", c.UserAgent)
 	}
-	logger.LogRequest(c.Logger, req)
+	reqID := uuid.New().String()
+	logger.LogRequest(c.Logger, req, reqID)
+	start := time.Now()
 	resp, err := c.HTTPClient.Do(req)
 	if err != nil {
 		return nil, err
 	}
-	logger.LogResponse(c.Logger, resp)
+	logger.LogResponse(c.Logger, resp, start, reqID)
 	if resp.StatusCode >= 299 {
 		return nil, checkErrorInResponse(resp, fmt.Errorf("api responded with code: %d", resp.StatusCode))
 	}


### PR DESCRIPTION
Log request ID and duration:
```
zpa-logger: 2023/04/07 13:40:50 logger.go:32: [DEBUG] Request "GET https://config.private.zscaler.com/mgmtconfig/v1/admin/customers/xxx/segmentGroup?page=1&pagesize=500" details:
---[ ZSCALER SDK REQUEST | ID:f7d4ffa8-1db0-4bc7-9b58-f2e8e56eaa49 ]-------------------------------
GET /mgmtconfig/v1/admin/customers/xxx/segmentGroup?page=1&pagesize=500 HTTP/1.1
Host: config.private.zscaler.com
User-Agent: userAgent
Authorization: Bearer ...
Content-Type: application/json
Accept-Encoding: gzip


---------------------------------------------------------
zpa-logger: 2023/04/07 13:40:53 logger.go:32: [DEBUG] Response "GET https://config.private.zscaler.com/mgmtconfig/v1/admin/customers/xxx/segmentGroup?page=1&pagesize=500" details:
---[ ZSCALER SDK RESPONSE | ID:f7d4ffa8-1db0-4bc7-9b58-f2e8e56eaa49 | Duration:3.074032704s ]--------------------------------
HTTP/2.0 200 OK
Connection: close
Cache-Control: no-store
Content-Security-Policy: default-src 'none'; upgrade-insecure-requests
Content-Type: application/json;charset=utf-8
...
```