### PR TITLE
Potential fix for code scanning alert no. 71: Incorrect conversion between integer types

### DIFF
--- a/examples/zdx/alerts/main.go
+++ b/examples/zdx/alerts/main.go
@@ -98,7 +98,7 @@ func promptForFilters(reader *bufio.Reader, defaultTo14Days bool) common.GetFrom
 	fmt.Print("Enter start time in Unix Epoch (optional: Defaults to the previous 2 hours): ")
 	fromInput := readInput(reader)
 	if fromInput != "" {
-		parsedFrom, err := strconv.ParseInt(fromInput, 10, 64)
+		parsedFrom, err := strconv.ParseInt(fromInput, 10, 32)
 		if err != nil {
 			log.Fatalf("[ERROR] Invalid start time: %v\n", err)
 		}
@@ -108,7 +108,7 @@ func promptForFilters(reader *bufio.Reader, defaultTo14Days bool) common.GetFrom
 	fmt.Print("Enter end time in Unix Epoch (optional: Defaults to now): ")
 	toInput := readInput(reader)
 	if toInput != "" {
-		parsedTo, err := strconv.ParseInt(toInput, 10, 64)
+		parsedTo, err := strconv.ParseInt(toInput, 10, 32)
 		if err != nil {
 			log.Fatalf("[ERROR] Invalid end time: %v\n", err)
 		}

--- a/zscaler/zdx/services/common/common.go
+++ b/zscaler/zdx/services/common/common.go
@@ -32,8 +32,8 @@ type GetFromToFilters struct {
 
 // Centralized safe conversion function
 func SafeCastToInt(value int64) (int, error) {
-	minInt := int64(-1 << 31)      // Minimum value of int
-	maxInt := int64((1 << 31) - 1) // Maximum value of int
+	minInt := int64(-1 << 31)      // Minimum value of int32
+	maxInt := int64((1 << 31) - 1) // Maximum value of int32
 
 	if value < minInt || value > maxInt {
 		return 0, fmt.Errorf("value %d is out of range for int type", value)


### PR DESCRIPTION
Potential fix for [https://github.com/zscaler/zscaler-sdk-go/security/code-scanning/71](https://github.com/zscaler/zscaler-sdk-go/security/code-scanning/71)

To fix the problem, we need to ensure that the conversion from `int64` to `int` is handled correctly, considering the bit size of the `int` type on the system. We can achieve this by using the `strconv.ParseInt` function with a specified bit size that matches the `int` type and then performing the conversion. Additionally, we should ensure that the bounds check in the `SafeCastToInt` function is appropriate for the system's `int` type.

1. Use `strconv.ParseInt` with a bit size of 32 when parsing the input string.
2. Ensure the `SafeCastToInt` function performs bounds checking for the appropriate bit size of the `int` type.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
