### PR TITLE
Update CHANGELOG for docs and YAML fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,11 @@
 ## Notes
 - Golang: **v1.23**
 
+### Documentation
+- Fixed README typos and clarified service detection description.
+
 ### Bug Fixes
+- Corrected YAML tag in `.goreleaser.yml`.
 
 [PR #339](https://github.com/zscaler/zscaler-sdk-go/pull/339) - Fixed an issue in the OneAPI client where initial API requests could fail with 401 Unauthorized if a valid OAuth2 token had not yet been obtained. The client now performs immediate authentication before starting the background token renewal ticker, ensuring the token is always present on first use. Removed incorrect retry logic for 401 responses.
 


### PR DESCRIPTION
## Summary
- document README typo fixes and YAML tag correction as part of the 3.4.3 entry

## Testing
- `make test` *(fails: Go modules require network access)*

------
https://chatgpt.com/codex/tasks/task_e_683f3d8de26c8326a55104e0233af070