### PR TITLE
Fix(ZIA): Restrict response retries and preserve exhausted responses

### DIFF
--- a/zscaler/zia/v2_client.go
+++ b/zscaler/zia/v2_client.go
@@ -394,6 +394,7 @@ func getHTTPClient(l logger.Logger, rateLimiter *rl.RateLimiter, cfg *Configurat
 		return sleep
 	}
 	retryableClient.CheckRetry = checkRetry
+	retryableClient.ErrorHandler = retryablehttp.PassthroughErrorHandler
 	retryableClient.Logger = l
 
 	// Set the request timeout, allowing user-defined override.
@@ -523,7 +524,12 @@ func checkRetry(ctx context.Context, resp *http.Response, err error) (bool, erro
 			}
 		}
 	}
-	return retryablehttp.DefaultRetryPolicy(ctx, resp, err)
+	if err != nil {
+	// Preserve retryablehttp's classification of transport failures
+		return retryablehttp.DefaultRetryPolicy(ctx, resp, err)
+	}
+	// HTTP response statuses are retryable only when explicitly handled above
+	return false, nil
 }
 
 // validateSession checks if the current session is still valid by making a GET request to /authenticatedSession

--- a/zscaler/zia/v2_client_ratelimit_test.go
+++ b/zscaler/zia/v2_client_ratelimit_test.go
@@ -1,10 +1,12 @@
 package zia
 
 import (
+	"context"
 	"bytes"
 	"io"
 	"math"
 	"net/http"
+	"net/http/httptest"
 	"testing"
 	"time"
 
@@ -12,6 +14,116 @@ import (
 	"github.com/zscaler/zscaler-sdk-go/v3/logger"
 	rl "github.com/zscaler/zscaler-sdk-go/v3/ratelimiter"
 )
+
+// TestZIACheckRetry tests ZIA Retry logic
+func TestZIACheckRetry(t *testing.T) {
+	tests := []struct {
+		name string
+		resp *http.Response
+		err  error
+		want bool
+	}{
+		{
+			name: "retries 429",
+			resp: &http.Response{
+				StatusCode: http.StatusTooManyRequests,
+				Body:       io.NopCloser(bytes.NewBuffer(nil)),
+			},
+			want: true,
+		},
+		{
+			name: "does not retry generic 500",
+			resp: &http.Response{
+				StatusCode: http.StatusInternalServerError,
+				Body: io.NopCloser(bytes.NewBufferString(
+					`{"code":"UNEXPECTED_ERROR"}`,
+				)),
+			},
+			want: false,
+		},
+		{
+			name: "retries transport error",
+			err:  io.EOF,
+			want: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			retry, err := checkRetry(
+				context.Background(),
+				tt.resp,
+				tt.err,
+			)
+
+			require.NoError(t, err)
+			require.Equal(t, tt.want, retry)
+		})
+	}
+}
+
+//TestZIARetryBehaviour tests the retry behaviour
+func TestZIARetryBehavior(t *testing.T) {
+	tests := []struct {
+		name         string
+		status       int
+		wantAttempts int
+	}{
+		{
+			name:         "500 returns immediately",
+			status:       http.StatusInternalServerError,
+			wantAttempts: 1,
+		},
+		{
+			name:         "429 preserves response after retry exhaustion",
+			status:       http.StatusTooManyRequests,
+			wantAttempts: 2,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			attempts := make(chan struct{}, 2)
+
+			server := httptest.NewServer(http.HandlerFunc(
+				func(w http.ResponseWriter, r *http.Request) {
+					attempts <- struct{}{}
+					w.Header().Set("Content-Type", "application/json")
+					if tt.status == http.StatusTooManyRequests {
+						w.Header().Set("Retry-After", "1ms")
+					}
+					w.WriteHeader(tt.status)
+					_, _ = w.Write([]byte(`{"code":"TEST_ERROR"}`))
+				},
+			))
+			defer server.Close()
+
+			l := logger.GetDefaultLogger("zia-retry-test: ")
+			cfg := &Configuration{Logger: l}
+			cfg.ZIA.Client.RateLimit.MaxRetries = 1
+			cfg.ZIA.Client.RateLimit.RetryWaitMin = time.Millisecond
+			cfg.ZIA.Client.RateLimit.RetryWaitMax = time.Millisecond
+			cfg.ZIA.Client.RequestTimeout = 5 * time.Second
+
+			client := getHTTPClient(
+				l,
+				rl.NewRateLimiter(20, 10, 10, 10),
+				cfg,
+			)
+
+			resp, err := client.Get(server.URL)
+			require.NoError(t, err)
+			defer resp.Body.Close()
+
+			require.Equal(t, tt.status, resp.StatusCode)
+			require.Len(t, attempts, tt.wantAttempts)
+
+			body, err := io.ReadAll(resp.Body)
+			require.NoError(t, err)
+			require.JSONEq(t, `{"code":"TEST_ERROR"}`, string(body))
+		})
+	}
+}
 
 // TestZIABackoffLogic tests the ZIA backoff function behavior
 func TestZIABackoffLogic(t *testing.T) {


### PR DESCRIPTION
## Description

The ZIA client’s retry policy explicitly identified 429 and several known lock/session errors as retryable. However, every other response was passed to retryablehttp.DefaultRetryPolicy, which retries almost all 5xx responses.

This would cause:

- Generic 500 responses to be retried even when the request was invalid
- POST requests could be replayed unnecessarily creating risk of duplicate mutations
- The default configuration could retry an already failed request up to 101 times over approximately 34 minutes (this is the initial behavior I found that caused my investigation into this).
- When retries were exhausted retryablehttp closed the final response body
- A context deadline could expire during backoff and replace the useful API error with context deadline exceeded

The existing tests did not expose this because they tested backoff and rate limiting without calling the retry-classification function.

The updated policy treats HTTP response retries as explicit:

- 429 responses remain retryable.
- Existing recognized lock and session errors remain retryable.
- Transport failures continue using retryablehttp’s established classification.
- Generic 500 and other unlisted HTTP responses return immediately without retrying.
- When an explicitly retryable response exhausts its retry budget, PassthroughErrorHandler preserves the final response.
- The existing ZIA error handling can then return a structured *errorx.ErrorResponse containing the status, API code, message, and raw body.

## Has your change been tested?

I added 2 new tests to v2_client_ratelimit_test.go:

- TestZIACheckRetry tests against the checkRetry function for status codes 429 and 500 as well as transport errors
- TestZIARetryBehavior uses httptest.NewServer to test that recognized 429 status codes are retried and expose the final response body and 500 status codes are not retried and expose the error response.

I also created a configuration to test against my ZIA environment where I added ziaCfg.HTTPClient = &http.Client{Timeout: 30 * time.Second} to bypass retryablehttp to preserve the response causing my 101 retries and found the 500 error. That led me to where the changes were needed.

I will use that configuration to test against my environment again tonight if needed and can this PR with the outcome.

## Types of changes

What sort of change does your code introduce/modify?

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] This change is using publicly documented and stable APIs.

[1]: https://help.github.com/articles/closing-issues-using-keywords/
